### PR TITLE
Add a --aliyunecs-internet-charge-type parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ docker-machine create -d aliyunecs --help
 ``--aliyunecs-io-optimized``| The I/O optimized instance type, the valid values could be `none` (default) or `optimized`||
 ``--aliyunecs-instance-type``| The instance type to run.  Default: `ecs.n4.small`||
 ``--aliyunecs-internet-max-bandwidth``| Maximum bandwidth for Internet access (in Mbps), default 1||
+``--aliyunecs-internet-charge-type``| [Internet charge type](https://www.alibabacloud.com/help/doc-detail/25411.htm), the valid values could be `PayByTraffic` (default) or `PayByBandwidth`||
 ``--aliyunecs-private-address-only``| Use the private IP address only||
 ``--aliyunecs-region``| The region to use when launching the instance. Default: `cn-hangzhou`||
 ``--aliyunecs-route-cidr``| The CIDR to use configure the route entry for the instance in VPC. Sample: 192.168.200.0/24||
@@ -115,11 +116,10 @@ docker-machine create -d aliyunecs --help
 ``--aliyunecs-ssh-password``| SSH password for created virtual machine. Default is random generated.||
 ``--aliyunecs-ssh-keypair``| SSH key pair name ||
 ``--aliyunecs-ssh-keypath``| File path of SSH private key ||
-``--aliyunecs-system-disk-category``|System disk category for instance||
 ``--aliyunecs-tag``| Tag for the instance.||
 ``--aliyunecs-vpc-id``| Your VPC ID to launch the instance in. (required for VPC network only)||
 ``--aliyunecs-vswitch-id``| Your VSwitch ID to launch the instance with. (required for VPC network only)||
-``--aliyunecs-zone``| The availabilty zone to launch the instance||
+``--aliyunecs-zone``| The availability zone to launch the instance||
 
 ## Environment variables and default values:
 
@@ -138,6 +138,7 @@ docker-machine create -d aliyunecs --help
 | `--aliyunecs-aliyunecs-io-optimized`| `ECS_IO_OPTIMIZED`          | `none`           |
 | `--aliyunecs-instance-type`         | `ECS_INSTANCE_TYPE`         | `ecs.t1.small`   |
 | `--aliyunecs-internet-max-bandwidth`| `ECS_INTERNET_MAX_BANDWIDTH`| `1`              |
+| `--aliyunecs-internet-charge-type`  | `ECS_INTERNET_CHARGE_TYPE`  | `PayByTraffic`   |
 | `--aliyunecs-private-address-only`  | `ECS_PRIVATE_ADDR_ONLY`     | `false`          |
 | `--aliyunecs-region`                | `ECS_REGION`                | `cn-hangzhou`    |
 | `--aliyunecs-route-cidr`            | `ECS_ROUTE_CIDR`            | -                |


### PR DESCRIPTION
This change fixes a bug that prevented users to create a docker machine outside of Mainland China: when allocating an EIP, the `InternetChargeType` parameter was not set, so the internal system of Alibaba Cloud automatically set it to `PayByBandwidth`, which is not supported outside of China.

This fix allows users to set the `InternetChargeType` parameter to `PayByTraffic` and `PayByBandwidth`. The default value has been set to `PayByTraffic` (the internetChargeType constant at the beginning of aliyunecs/ecs.go was already set to "PayByTraffic").